### PR TITLE
Force Curl to use TLS v1.2

### DIFF
--- a/lib/Splash/Chargify/Client.php
+++ b/lib/Splash/Chargify/Client.php
@@ -149,7 +149,7 @@ class Client {
     public function getCurl() {
         if ($this->curl === null) {
             $this->curl = curl_init();
-            
+
             curl_setopt_array($this->curl, array(
                 CURLOPT_SSL_VERIFYPEER => false,
                 CURLOPT_SSL_VERIFYHOST => 2,
@@ -158,6 +158,9 @@ class Client {
                 CURLOPT_RETURNTRANSFER => true,
                 CURLOPT_CONNECTTIMEOUT => 10,
                 CURLOPT_TIMEOUT        => 30,
+                //Using integer value instead constant because in CentOS
+                //Curl uses NSS and there CURL_SSLVERSION_TLSv1_2 is undefined
+                CURLOPT_SSLVERSION     => 6,
             ));
         }
 


### PR DESCRIPTION
Chargify changed to TLS v1.2 and after that change at least in CentOS client is unable to connect Chargify's API. This change adds ssl version option to curl options.
